### PR TITLE
Merge in Final Solver logic

### DIFF
--- a/solver/general/brute_force.py
+++ b/solver/general/brute_force.py
@@ -16,7 +16,7 @@ class BruteForceSolver(object):
         self.adj_matrix = adj_matrix
 
     def maximum_acyclic_subgraph(self):
-        vertices = range(1, len(self.adj_matrix) + 1)
+        vertices = range(len(self.adj_matrix))
         vertex_permutations = permutations(vertices)
         max_score = 0
         max_ordering = vertices

--- a/solver/general/final_solver.py
+++ b/solver/general/final_solver.py
@@ -70,11 +70,10 @@ class FinalSolver(object):
                 scc_solution = scc
                 for i in range(10000):
                     this_solution = two_approx_solver.maximum_acyclic_subgraph()
-                    score = scoreSolution(scc, this_solution)
+                    score = scoreSolution(scc_adj_matrix, this_solution)
                     if score > max_score:
                         max_score = score
                         scc_solution = this_solution
             solution.extend(scc_solution)
 
-        solution = map(lambda x: (int(x) + 1), solution)
         return solution

--- a/solver/staff/scorer_single.py
+++ b/solver/staff/scorer_single.py
@@ -42,7 +42,6 @@ def scoreSolution(inst, sol):
     for i in range(len(inst)):
         e += sum(inst[i])
 
-    sol = map(lambda x: (int(x) - 1), sol)
     count = 0.0
     for i in xrange(N):
         for j in xrange(i + 1, N):

--- a/tests/test_brute_force.py
+++ b/tests/test_brute_force.py
@@ -16,17 +16,17 @@ class BruteForceTest(unittest.TestCase):
         self.matrix_input_dag_one = Parser(self.test_input_dag_one).generate_matrix()
 
     def test_brute_force(self):
-        expected_output_one = [1, 3, 2, 4]
+        expected_output_one = [0, 2, 1, 3]
         observed_output_one = \
             BruteForceSolver(self.matrix_input_one).maximum_acyclic_subgraph()
         self.assertEqual(expected_output_one, observed_output_one)
 
-        expected_output_cycle = [1, 2, 3, 4]
+        expected_output_cycle = [0, 1, 2, 3]
         observed_output_cycle = \
             BruteForceSolver(self.matrix_input_cycle).maximum_acyclic_subgraph()
         self.assertEqual(expected_output_cycle, observed_output_cycle)
 
-        expected_output_dag_one = [1, 2, 3, 4]
+        expected_output_dag_one = [0, 1, 2, 3]
         observed_output_dag_one = \
             BruteForceSolver(self.matrix_input_dag_one).maximum_acyclic_subgraph()
         self.assertEqual(expected_output_dag_one, observed_output_dag_one)

--- a/tests/test_final_solver.py
+++ b/tests/test_final_solver.py
@@ -42,7 +42,7 @@ class FinalSolverTest(unittest.TestCase):
         '''
         random.seed(170)
 
-        expected_output_one = [2, 1, 3, 0]
+        expected_output_one = [0, 2, 1, 3]
         observed_output_one = \
             FinalSolver(self.matrix_input_one).maximum_acyclic_subgraph()
         self.assertEquals(observed_output_one, expected_output_one)
@@ -52,7 +52,7 @@ class FinalSolverTest(unittest.TestCase):
             FinalSolver(self.matrix_input_dag_one).maximum_acyclic_subgraph()
         self.assertEquals(observed_output_dag_one, expected_output_dag_one)
 
-        expected_output_cycle = [3, 0, 1, 2]
+        expected_output_cycle = [0, 1, 2, 3]
         observed_output_cycle = \
             FinalSolver(self.matrix_input_cycle).maximum_acyclic_subgraph()
         self.assertEquals(observed_output_cycle, expected_output_cycle)
@@ -64,12 +64,12 @@ class FinalSolverTest(unittest.TestCase):
             FinalSolver(self.matrix_input_dag_two).maximum_acyclic_subgraph()
         self.assertEquals(observed_output_dag_two, expected_output_dag_two)
 
-        expected_output_nonplanar_one = [1, 2, 3, 9, 10, 11, 13, 4, 5, 6, 7, 12, 8, 0]
+        expected_output_nonplanar_one = [9, 0, 1, 6, 7, 8, 2, 3, 4, 10, 5, 11, 12, 13]
         observed_output_nonplanar_one = \
             FinalSolver(self.matrix_input_nonplanar_one).maximum_acyclic_subgraph()
         self.assertEquals(observed_output_nonplanar_one, expected_output_nonplanar_one)
 
-        expected_output_nonplanar_two = [3, 1, 0, 5, 7, 6, 4, 2]
+        expected_output_nonplanar_two = [5, 0, 7, 6, 4, 3, 1, 2]
         observed_output_nonplanar_two = \
             FinalSolver(self.matrix_input_nonplanar_two).maximum_acyclic_subgraph()
         self.assertEquals(observed_output_nonplanar_two, expected_output_nonplanar_two)


### PR DESCRIPTION
Taken from the DocString:
Here's the strategy for the final solver:
    1. Try to run a topological sort on G. This will only work if G is
        a DAG.
    2. Divide the graph into it's strongly connected components.
        a. For all subgraphs of size > 8, run the TwoApproximationSolver on
            it 10000 times. This will likely find a pretty good subgraph MAS.
        b. Otherwise, brute force it.

This will run fairly well on all instances except ones in which there is one single, large, strongly connected component. This will be the motivation for the extreme cases.
